### PR TITLE
Examples update

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ git clone https://github.com/strowk/foxy-contexts
 cd foxy-contexts/examples/list_current_dir_files_tool
 npx @modelcontextprotocol/inspector go run main.go
 ```
-, then once inspector is started in browser open http://localhost:5173 and try to use list-current-dir-files.
+, then once inspector is started in browser open http://localhost:6274 and try to use list-current-dir-files.
 
 Here's the code of that example from [examples/list_current_dir_files_tool/main.go](https://github.com/strowk/foxy-contexts/blob/main/examples/list_current_dir_files_tool/main.go) (in real world application you would probably want to split it into multiple files):
 
@@ -95,7 +95,7 @@ import (
 // This example defines list-current-dir-files tool for MCP server, that prints files in the current directory
 // , run it with:
 // npx @modelcontextprotocol/inspector go run main.go
-// , then in browser open http://localhost:5173
+// , then in browser open http://localhost:6274
 // , then click Connect
 // , then click List Tools
 // , then click list-current-dir-files

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -73,7 +73,7 @@ git clone https://github.com/strowk/foxy-contexts
 cd foxy-contexts/examples/list_current_dir_files_tool
 npx @modelcontextprotocol/inspector go run main.go
 ```
-, then once inspector is started in browser open http://localhost:5173 and try to use list-current-dir-files.
+, then once inspector is started in browser open http://localhost:6274 and try to use list-current-dir-files.
 
 Here's the code of that example from [examples/list_current_dir_files_tool/main.go](https://github.com/strowk/foxy-contexts/blob/main/examples/list_current_dir_files_tool/main.go) (in real world application you would probably want to split it into multiple files):
 
@@ -97,7 +97,7 @@ import (
 // This example defines list-current-dir-files tool for MCP server, that prints files in the current directory
 // , run it with:
 // npx @modelcontextprotocol/inspector go run main.go
-// , then in browser open http://localhost:5173
+// , then in browser open http://localhost:6274
 // , then click Connect
 // , then click List Tools
 // , then click list-current-dir-files

--- a/examples/git_repository_resource/main.go
+++ b/examples/git_repository_resource/main.go
@@ -20,7 +20,7 @@ func main() {
 	// This example defines resource tool for MCP server, that shows information about a current git repository
 	// , run it with:
 	// npx @modelcontextprotocol/inspector go run main.go
-	// , then in browser open http://localhost:5173
+	// , then in browser open http://localhost:6274
 	// , then click Connect
 	// , then click List Resources
 	// , then click current-git-repository

--- a/examples/git_repository_resource/main.go
+++ b/examples/git_repository_resource/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/strowk/foxy-contexts/internal/utils"
 	"github.com/strowk/foxy-contexts/pkg/app"
 	"github.com/strowk/foxy-contexts/pkg/fxctx"
 	"github.com/strowk/foxy-contexts/pkg/mcp"
@@ -33,8 +34,8 @@ func main() {
 				mcp.Resource{
 					Name:        "current-git-repository",
 					Uri:         "git://current-git-repository",
-					MimeType:    Ptr("application/json"),
-					Description: Ptr("Shows information about a current git repository"),
+					MimeType:    utils.Ptr("application/json"),
+					Description: utils.Ptr("Shows information about a current git repository"),
 					Annotations: &mcp.ResourceAnnotations{
 						Audience: []mcp.Role{
 							mcp.RoleAssistant, mcp.RoleUser,
@@ -77,7 +78,7 @@ func main() {
 					return &mcp.ReadResourceResult{
 						Contents: []interface{}{
 							mcp.TextResourceContents{
-								MimeType: Ptr("application/json"),
+								MimeType: utils.Ptr("application/json"),
 								Text:     string(data),
 								Uri:      uri,
 							},
@@ -85,6 +86,12 @@ func main() {
 					}, nil
 				},
 			)
+		}).
+		WithServerCapabilities(&mcp.ServerCapabilities{
+			Resources: &mcp.ServerCapabilitiesResources{
+				ListChanged: utils.Ptr(false),
+				Subscribe:   utils.Ptr(false),
+			},
 		}).
 		// setting up server
 		WithName("my-mcp-server").
@@ -104,12 +111,7 @@ func main() {
 				},
 			)),
 		).Run()
-
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-func Ptr[T any](v T) *T {
-	return &v
 }

--- a/examples/hello_world_resource/main.go
+++ b/examples/hello_world_resource/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/strowk/foxy-contexts/internal/utils"
 	"github.com/strowk/foxy-contexts/pkg/app"
 	"github.com/strowk/foxy-contexts/pkg/fxctx"
 	"github.com/strowk/foxy-contexts/pkg/mcp"
@@ -27,8 +28,8 @@ func NewGreatResource() fxctx.Resource {
 		mcp.Resource{
 			Name:        "hello-world",
 			Uri:         "hello-world://hello-world",
-			MimeType:    Ptr("application/json"),
-			Description: Ptr("Hello World Resource"),
+			MimeType:    utils.Ptr("application/json"),
+			Description: utils.Ptr("Hello World Resource"),
 			Annotations: &mcp.ResourceAnnotations{
 				Audience: []mcp.Role{
 					mcp.RoleAssistant, mcp.RoleUser,
@@ -39,7 +40,7 @@ func NewGreatResource() fxctx.Resource {
 			return &mcp.ReadResourceResult{
 				Contents: []interface{}{
 					mcp.TextResourceContents{
-						MimeType: Ptr("application/json"),
+						MimeType: utils.Ptr("application/json"),
 						Text:     `{"hello": "world"}`,
 						Uri:      uri,
 					},
@@ -57,6 +58,12 @@ func main() {
 		NewBuilder().
 		// adding the resource to the app
 		WithResource(NewGreatResource).
+		WithServerCapabilities(&mcp.ServerCapabilities{
+			Resources: &mcp.ServerCapabilitiesResources{
+				ListChanged: utils.Ptr(false),
+				Subscribe:   utils.Ptr(false),
+			},
+		}).
 		// setting up server
 		WithName("my-mcp-server").
 		WithVersion("0.0.1").
@@ -75,14 +82,9 @@ func main() {
 				},
 			)),
 		).Run()
-
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
 // --8<-- [end:server]
-
-func Ptr[T any](v T) *T {
-	return &v
-}

--- a/examples/hello_world_resource/main.go
+++ b/examples/hello_world_resource/main.go
@@ -16,7 +16,7 @@ import (
 // This example defines resource tool for MCP server
 // , run it with:
 // npx @modelcontextprotocol/inspector go run main.go
-// , then in browser open http://localhost:5173
+// , then in browser open http://localhost:6274
 // , then click Connect
 // , then click List Resources
 // , then click hello-world

--- a/examples/initialized_callback/main.go
+++ b/examples/initialized_callback/main.go
@@ -67,7 +67,3 @@ func main() {
 }
 
 // --8<-- [end:server]
-
-func Ptr[T any](v T) *T {
-	return &v
-}

--- a/examples/initialized_callback/main.go
+++ b/examples/initialized_callback/main.go
@@ -15,7 +15,7 @@ import (
 // some workafter the client has finished initialization and notified the server
 // , run it with:
 // npx @modelcontextprotocol/inspector go run main.go
-// , then in browser open http://localhost:5173
+// , then in browser open http://localhost:6274
 // , then click Connect
 
 // --8<-- [start:server]

--- a/examples/k8s_contexts_resources/README.md
+++ b/examples/k8s_contexts_resources/README.md
@@ -12,7 +12,7 @@ To try this example with inspector, run the following command:
 npx @modelcontextprotocol/inspector go run main.go
 ```
 
-Then in browser open http://localhost:5173
+Then in browser open http://localhost:6274
 , then click Connect
 , then click List Resources
 , you should see list of contexts and could click on them to see details

--- a/examples/list_current_dir_files_tool/README.md
+++ b/examples/list_current_dir_files_tool/README.md
@@ -12,7 +12,7 @@ To try this example with inspector, run the following command:
 npx @modelcontextprotocol/inspector go run main.go
 ```
 
-Then in browser open http://localhost:5173
+Then in browser open http://localhost:6274
 then click Connect
 then click List Tools
 then click list-current-dir-files

--- a/examples/list_current_dir_files_tool/main.go
+++ b/examples/list_current_dir_files_tool/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/strowk/foxy-contexts/internal/utils"
 	"github.com/strowk/foxy-contexts/pkg/app"
 	"github.com/strowk/foxy-contexts/pkg/fxctx"
 	"github.com/strowk/foxy-contexts/pkg/mcp"
@@ -28,7 +29,7 @@ func NewListCurrentDirFilesTool() fxctx.Tool {
 		// This information about the tool would be used when it is listed:
 		&mcp.Tool{
 			Name:        "list-current-dir-files",
-			Description: Ptr("Lists files in the current directory"),
+			Description: utils.Ptr("Lists files in the current directory"),
 			InputSchema: mcp.ToolInputSchema{
 				Type:       "object",
 				Properties: map[string]map[string]interface{}{},
@@ -41,7 +42,7 @@ func NewListCurrentDirFilesTool() fxctx.Tool {
 			files, err := os.ReadDir(".")
 			if err != nil {
 				return &mcp.CallToolResult{
-					IsError: Ptr(true),
+					IsError: utils.Ptr(true),
 					Meta:    map[string]interface{}{},
 					Content: []interface{}{
 						mcp.TextContent{
@@ -62,7 +63,7 @@ func NewListCurrentDirFilesTool() fxctx.Tool {
 			return &mcp.CallToolResult{
 				Meta:    map[string]interface{}{},
 				Content: contents,
-				IsError: Ptr(false),
+				IsError: utils.Ptr(false),
 			}
 		},
 	)
@@ -73,6 +74,11 @@ func main() {
 		NewBuilder().
 		// adding the tool to the app
 		WithTool(NewListCurrentDirFilesTool).
+		WithServerCapabilities(&mcp.ServerCapabilities{
+			Tools: &mcp.ServerCapabilitiesTools{
+				ListChanged: utils.Ptr(false),
+			},
+		}).
 		// setting up server
 		WithName("list-current-dir-files").
 		WithVersion("0.0.1").
@@ -91,8 +97,4 @@ func main() {
 				},
 			)),
 		).Run()
-}
-
-func Ptr[T any](v T) *T {
-	return &v
 }

--- a/examples/list_current_dir_files_tool/main.go
+++ b/examples/list_current_dir_files_tool/main.go
@@ -17,7 +17,7 @@ import (
 // This example defines list-current-dir-files tool for MCP server, that prints files in the current directory
 // , run it with:
 // npx @modelcontextprotocol/inspector go run main.go
-// , then in browser open http://localhost:5173
+// , then in browser open http://localhost:6274
 // , then click Connect
 // , then click List Tools
 // , then click list-current-dir-files

--- a/examples/list_k8s_contexts_tool/README.md
+++ b/examples/list_k8s_contexts_tool/README.md
@@ -14,7 +14,7 @@ To try this example with inspector, run the following command:
 npx @modelcontextprotocol/inspector go run main.go
 ```
 
-Then in browser open http://localhost:5173
+Then in browser open http://localhost:6274
 then click Connect
 then click List Tools
 then click list-k8s-contexts

--- a/examples/list_k8s_contexts_tool/main.go
+++ b/examples/list_k8s_contexts_tool/main.go
@@ -21,8 +21,8 @@ import (
 
 // This example defines list-k8s-contexts tool for MCP server, that uses k8s client-go to list available contexts
 // and returns them as a response, run it with:
-// npx @modelcontextprotocol/inspector go run main.go
-// , then in browser open http://localhost:5173
+// npx @modelcontextprotocol/inspector go run .
+// , then in browser open http://localhost:6274
 // , then click Connect
 // , then click List Tools
 // , then click list-k8s-contexts

--- a/examples/list_k8s_contexts_tool/main.go
+++ b/examples/list_k8s_contexts_tool/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/strowk/foxy-contexts/internal/utils"
 	"github.com/strowk/foxy-contexts/pkg/app"
 	"github.com/strowk/foxy-contexts/pkg/fxctx"
 	"github.com/strowk/foxy-contexts/pkg/mcp"
@@ -40,7 +41,7 @@ func NewListK8sContextsTool(kubeConfig clientcmd.ClientConfig) fxctx.Tool { // -
 		// This information about the tool would be used when it is listed:
 		&mcp.Tool{
 			Name:        "list-k8s-contexts",
-			Description: Ptr("List Kubernetes contexts from configuration files such as kubeconfig"),
+			Description: utils.Ptr("List Kubernetes contexts from configuration files such as kubeconfig"),
 			InputSchema: schema.GetMcpToolInputSchema(),
 		},
 
@@ -50,7 +51,7 @@ func NewListK8sContextsTool(kubeConfig clientcmd.ClientConfig) fxctx.Tool { // -
 			if err != nil {
 				log.Printf("failed to validate input: %v", err)
 				return &mcp.CallToolResult{
-					IsError: Ptr(true),
+					IsError: utils.Ptr(true),
 					Content: []interface{}{
 						mcp.TextContent{
 							Type: "text",
@@ -71,7 +72,7 @@ func NewListK8sContextsTool(kubeConfig clientcmd.ClientConfig) fxctx.Tool { // -
 			if err != nil {
 				log.Printf("failed to get kubeconfig: %v", err)
 				return &mcp.CallToolResult{
-					IsError: Ptr(true),
+					IsError: utils.Ptr(true),
 					Meta:    map[string]interface{}{},
 					Content: []interface{}{
 						mcp.TextContent{
@@ -85,7 +86,7 @@ func NewListK8sContextsTool(kubeConfig clientcmd.ClientConfig) fxctx.Tool { // -
 			return &mcp.CallToolResult{
 				Meta:    map[string]interface{}{},
 				Content: getListContextsToolContent(cfg),
-				IsError: Ptr(false),
+				IsError: utils.Ptr(false),
 			}
 		},
 	)
@@ -99,6 +100,11 @@ func main() {
 			fx.Provide(NewK8sClientConfig),
 		).
 		WithTool(NewListK8sContextsTool). // --8<-- [end:dependency_provide]
+		WithServerCapabilities(&mcp.ServerCapabilities{
+			Tools: &mcp.ServerCapabilitiesTools{
+				ListChanged: utils.Ptr(false),
+			},
+		}).
 		WithTransport(stdio.NewTransport()).
 		WithName("list-k8s-contexts-tool").
 		WithVersion("0.0.1").
@@ -117,7 +123,6 @@ func main() {
 			)),
 		).
 		Run()
-
 }
 
 func getListContextsToolContent(cfg api.Config) []interface{} {
@@ -144,8 +149,4 @@ func getListContextsToolContent(cfg api.Config) []interface{} {
 type ContextJsonEncoded struct {
 	Context *api.Context `json:"context"`
 	Name    string       `json:"name"`
-}
-
-func Ptr[T any](v T) *T {
-	return &v
 }

--- a/examples/list_k8s_namespaces_prompt/README.md
+++ b/examples/list_k8s_namespaces_prompt/README.md
@@ -14,7 +14,7 @@ To try this example with inspector, run the following command:
 npx @modelcontextprotocol/inspector go run main.go
 ```
 
-Then in browser open http://localhost:5173
+Then in browser open http://localhost:6274
 
 , then click Connect
 , then go to Prompts

--- a/examples/list_k8s_namespaces_prompt/main.go
+++ b/examples/list_k8s_namespaces_prompt/main.go
@@ -23,7 +23,7 @@ func main() {
 	// This example defines list-k8s-contexts prompt for MCP server, that uses k8s client-go to list available namespaces
 	// and returns them as a response, run it with:
 	// npx @modelcontextprotocol/inspector go run main.go
-	// , then in browser open http://localhost:5173
+	// , then in browser open http://localhost:6274
 	// , then click Connect
 	// , then go to Prompts
 	// , then click List Prompts

--- a/examples/list_k8s_namespaces_prompt/main.go
+++ b/examples/list_k8s_namespaces_prompt/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/strowk/foxy-contexts/internal/utils"
 	"github.com/strowk/foxy-contexts/pkg/fxctx"
 	"github.com/strowk/foxy-contexts/pkg/mcp"
 	"github.com/strowk/foxy-contexts/pkg/server"
@@ -34,17 +35,16 @@ func main() {
 		// Here we define a prompt that lists k8s contexts using client-go
 		fx.Provide(fxctx.AsPrompt(
 			func() fxctx.Prompt {
-
 				return fxctx.NewPrompt(
 					// This information about the prompt would be used when it is listed:
 					mcp.Prompt{
 						Name:        "list-k8s-namespaces",
-						Description: Ptr("List Kubernetes namespaces"),
+						Description: utils.Ptr("List Kubernetes namespaces"),
 						Arguments: []mcp.PromptArgument{
 							{
-								Description: Ptr("Kubernetes context"),
+								Description: utils.Ptr("Kubernetes context"),
 								Name:        "context",
-								Required:    Ptr(true),
+								Required:    utils.Ptr(true),
 							},
 						},
 					},
@@ -75,7 +75,6 @@ func main() {
 						}
 
 						ns, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-
 						if err != nil {
 							log.Printf("failed to list namespaces: %v", err)
 							return nil, fmt.Errorf("failed to list namespaces: %w", err)
@@ -88,7 +87,6 @@ func main() {
 						}, len(ns.Items))
 
 						for i, n := range ns.Items {
-
 							namespaces[i] = struct {
 								Namespace string `json:"namespace"`
 							}{
@@ -104,7 +102,7 @@ func main() {
 
 						return &mcp.GetPromptResult{
 							Meta:        map[string]interface{}{},
-							Description: Ptr(fmt.Sprintf("Namespaces in context %s", k8sContext)),
+							Description: utils.Ptr(fmt.Sprintf("Namespaces in context %s", k8sContext)),
 							Messages: []mcp.PromptMessage{
 								{
 									Content: mcp.TextContent{
@@ -142,8 +140,8 @@ func main() {
 
 						return &mcp.CompleteResult{
 							Completion: mcp.CompleteResultCompletion{
-								HasMore: Ptr(false),
-								Total:   Ptr(len(contexts)),
+								HasMore: utils.Ptr(false),
+								Total:   utils.Ptr(len(contexts)),
 								Values:  contexts,
 							},
 						}, nil
@@ -169,7 +167,7 @@ func main() {
 						transport.Run(
 							&mcp.ServerCapabilities{
 								Prompts: &mcp.ServerCapabilitiesPrompts{
-									ListChanged: Ptr(false),
+									ListChanged: utils.Ptr(false),
 								},
 							},
 							&mcp.Implementation{
@@ -207,9 +205,4 @@ func main() {
 			},
 		)),
 	).Run()
-
-}
-
-func Ptr[T any](v T) *T {
-	return &v
 }

--- a/examples/resource_provider/main.go
+++ b/examples/resource_provider/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/strowk/foxy-contexts/internal/utils"
 	"github.com/strowk/foxy-contexts/pkg/app"
 	"github.com/strowk/foxy-contexts/pkg/fxctx"
 	"github.com/strowk/foxy-contexts/pkg/mcp"
@@ -30,14 +31,13 @@ func NewGreatResourceProvider() fxctx.ResourceProvider {
 			return []mcp.Resource{
 				{
 					Name:        "my-great-resource-one",
-					Description: Ptr("Does something great"),
+					Description: utils.Ptr("Does something great"),
 					Uri:         "/resources/great/one",
 				},
 			}, nil
 		},
 		//  This function reads the resource for a given uri to run when resources/read is requested:
 		func(_ context.Context, uri string) (*mcp.ReadResourceResult, error) {
-
 			// you would probably be doing something more complicated here
 			// like reading from a database or calling an external service
 			// based on what you have parsed from the uri
@@ -45,7 +45,7 @@ func NewGreatResourceProvider() fxctx.ResourceProvider {
 				return &mcp.ReadResourceResult{
 					Contents: []interface{}{
 						mcp.TextResourceContents{
-							MimeType: Ptr("application/json"),
+							MimeType: utils.Ptr("application/json"),
 							Text:     string(`{"great": "resource"}`),
 							Uri:      uri,
 						},
@@ -67,6 +67,12 @@ func main() {
 		NewBuilder().
 		// adding the resource provider to server
 		WithResourceProvider(NewGreatResourceProvider).
+		WithServerCapabilities(&mcp.ServerCapabilities{
+			Resources: &mcp.ServerCapabilitiesResources{
+				ListChanged: utils.Ptr(false),
+				Subscribe:   utils.Ptr(false),
+			},
+		}).
 		// setting up server
 		WithName("my-mcp-server").
 		WithVersion("0.0.1").
@@ -85,14 +91,9 @@ func main() {
 				},
 			)),
 		).Run()
-
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
 // --8<-- [end:server]
-
-func Ptr[T any](v T) *T {
-	return &v
-}

--- a/examples/resource_provider/main.go
+++ b/examples/resource_provider/main.go
@@ -17,7 +17,7 @@ import (
 // This example defines resource tool for MCP server
 // , run it with:
 // npx @modelcontextprotocol/inspector go run main.go
-// , then in browser open http://localhost:5173
+// , then in browser open http://localhost:6274
 // , then click Connect
 // , then click List Resources
 // , then click hello-world

--- a/examples/simple_great_tool/main.go
+++ b/examples/simple_great_tool/main.go
@@ -16,7 +16,7 @@ import (
 // This example defines my-great-tool tool for MCP server
 // , run it with:
 // npx @modelcontextprotocol/inspector go run main.go
-// , then in browser open http://localhost:5173
+// , then in browser open http://localhost:6274
 // , then click Connect
 // , then click List Tools
 // , then click my-great-tool

--- a/examples/simple_great_tool/main.go
+++ b/examples/simple_great_tool/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/strowk/foxy-contexts/internal/utils"
 	"github.com/strowk/foxy-contexts/pkg/app"
 	"github.com/strowk/foxy-contexts/pkg/fxctx"
 	"github.com/strowk/foxy-contexts/pkg/mcp"
@@ -27,7 +28,7 @@ func NewGreatTool() fxctx.Tool {
 		// This information about the tool would be used when it is listed:
 		&mcp.Tool{
 			Name:        "my-great-tool",
-			Description: Ptr("The great tool"),
+			Description: utils.Ptr("The great tool"),
 			InputSchema: mcp.ToolInputSchema{ // here we tell client what we expect as input
 				Type:       "object",
 				Properties: map[string]map[string]interface{}{},
@@ -58,6 +59,11 @@ func main() {
 		NewBuilder().
 		// adding the tool to the app
 		WithTool(NewGreatTool).
+		WithServerCapabilities(&mcp.ServerCapabilities{
+			Tools: &mcp.ServerCapabilitiesTools{
+				ListChanged: utils.Ptr(false),
+			},
+		}).
 		// setting up server
 		WithName("great-tool-server").
 		WithVersion("0.0.1").
@@ -79,7 +85,3 @@ func main() {
 }
 
 // --8<-- [end:server]
-
-func Ptr[T any](v T) *T {
-	return &v
-}

--- a/examples/simple_prompt/README.md
+++ b/examples/simple_prompt/README.md
@@ -12,7 +12,7 @@ To try this example with inspector, run the following command:
 npx @modelcontextprotocol/inspector go run main.go
 ```
 
-Then in browser open http://localhost:5173
+Then in browser open http://localhost:6274
 
 , then click Connect
 , then go to Prompts

--- a/examples/simple_prompt/go.mod
+++ b/examples/simple_prompt/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/google/uuid v1.6.0 // indirect
 	go.uber.org/dig v1.18.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect

--- a/examples/simple_prompt/go.sum
+++ b/examples/simple_prompt/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/examples/simple_prompt/main.go
+++ b/examples/simple_prompt/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/strowk/foxy-contexts/internal/utils"
 	"github.com/strowk/foxy-contexts/pkg/app"
 	"github.com/strowk/foxy-contexts/pkg/fxctx"
 	"github.com/strowk/foxy-contexts/pkg/mcp"
@@ -18,12 +19,12 @@ func NewGreatPrompt() fxctx.Prompt {
 		// This information about the prompt would be used when it is listed:
 		mcp.Prompt{
 			Name:        "my-great-prompt",
-			Description: Ptr("Doing something great"),
+			Description: utils.Ptr("Doing something great"),
 			Arguments: []mcp.PromptArgument{
 				{
-					Description: Ptr("An argument for the prompt"),
+					Description: utils.Ptr("An argument for the prompt"),
 					Name:        "arg-1",
-					Required:    Ptr(true),
+					Required:    utils.Ptr(true),
 				},
 			},
 		},
@@ -54,6 +55,11 @@ func main() {
 		NewBuilder().
 		// adding the tool to the app
 		WithPrompt(NewGreatPrompt).
+		WithServerCapabilities(&mcp.ServerCapabilities{
+			Prompts: &mcp.ServerCapabilitiesPrompts{
+				ListChanged: utils.Ptr(false),
+			},
+		}).
 		// setting up server
 		WithName("great-tool-server").
 		WithVersion("0.0.1").
@@ -75,7 +81,3 @@ func main() {
 }
 
 // --8<-- [end:server]
-
-func Ptr[T any](v T) *T {
-	return &v
-}

--- a/examples/streamable_http/main.go
+++ b/examples/streamable_http/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/strowk/foxy-contexts/internal/utils"
 	"github.com/strowk/foxy-contexts/pkg/app"
 	"github.com/strowk/foxy-contexts/pkg/fxctx"
 	"github.com/strowk/foxy-contexts/pkg/mcp"
@@ -38,7 +39,7 @@ func NewGreatTool(sm *session.SessionManager) fxctx.Tool {
 		// This information about the tool would be used when it is listed:
 		&mcp.Tool{
 			Name:        "my-great-tool",
-			Description: Ptr("The great tool"),
+			Description: utils.Ptr("The great tool"),
 			InputSchema: mcp.ToolInputSchema{ // here we tell client what we expect as input
 				Type:       "object",
 				Properties: map[string]map[string]interface{}{},
@@ -80,6 +81,11 @@ func main() {
 		NewBuilder().
 		// adding the tool to the app
 		WithTool(NewGreatTool).
+		WithServerCapabilities(&mcp.ServerCapabilities{
+			Tools: &mcp.ServerCapabilitiesTools{
+				ListChanged: utils.Ptr(false),
+			},
+		}).
 		// setting up server
 		WithName("great-tool-server").
 		WithVersion("0.0.1").
@@ -117,7 +123,3 @@ func main() {
 }
 
 // --8<-- [end:server]
-
-func Ptr[T any](v T) *T {
-	return &v
-}


### PR DESCRIPTION
Nothing too urgent here, but I was rolling through your examples getting to know MCP and Inspector and hit a couple snags.

- Looks like they've updated the client/server ports [here](https://github.com/modelcontextprotocol/inspector/commit/da9dd097655086180588cbfa0e79cba2dcf1b866)
- And the Inspector just blocks on `The connected server does not support any MCP capabilities` if no capabilities are defined [here](https://github.com/modelcontextprotocol/inspector/commit/d857e1462bbbb1b3cdbe877525f451184bda2bc2#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337R544-R549)

I'm also using `utils.Ptr` everywhere to be consistent.

Great project btw, found this super helpful as a first foray into practical use of MCP in Go.